### PR TITLE
Changed zoom to use movementMagnitude instead of drag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "afterlight-caves",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "afterlight-caves",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "a game where you shoot procedurally generated enemies in procedurally generated caves",
   "main": "main.js",
   "directories": {

--- a/static/game/creature.js
+++ b/static/game/creature.js
@@ -199,6 +199,8 @@ export class Creature extends Entity {
     this.bombOnDetonate = new Array();
     this.bombOnBlastCreature = new Array();
     this.onTouchEnemy = new Array();
+    this.maxSpeed = 24;
+    this.maxAccMag = 24;
 
     // bombs deal basic damage
     this.bombOnBlastCreature.push({

--- a/static/game/powerups/zoom.js
+++ b/static/game/powerups/zoom.js
@@ -1,12 +1,8 @@
 import { PowerUp } from "../powerup.js";
 import { Vector } from "../../modules/vector.js";
 import { Creature } from "../creature.js";
-
-//const MOVEMENT_MULTIPLIER = 1.25;
-const DRAG_FACTOR = 0.3;
-const DRAG_ADDEND = 2;
-const MIN_DRAG = 0.008;
-//const MAX_MOVEMENT_MULTIPLIER = ;
+const MOVEMENT_FACTOR = 1 / 5;
+const MAX_MOVEMENT_MULTIPLIER = 4;
 
 export class Zoom extends PowerUp {
   /**
@@ -26,8 +22,7 @@ export class Zoom extends PowerUp {
   apply(creature) {
     if (!this.isAtMax(creature)) {
       super.apply(creature);
-      //creature.movementMultiplier *= this.magnitude * MOVEMENT_MULTIPLIER;
-      creature.drag /= (this.magnitude + DRAG_ADDEND) * DRAG_FACTOR;
+      creature.movementMultiplier += this.magnitude * MOVEMENT_FACTOR;
     } else {
       this.overflowAction(creature);
     }
@@ -41,13 +36,16 @@ export class Zoom extends PowerUp {
    */
   isAtMax(creature) {
     // check if bulletRubberiness is already too high
-    if (creature.drag <= MIN_DRAG) {
+    if (creature.movementMultiplier >= MAX_MOVEMENT_MULTIPLIER) {
       return true;
     }
 
     // see if we need to trim magnitude
     const availMag = Math.floor(
-      Math.abs(creature.drag / MIN_DRAG) / DRAG_FACTOR
+      Math.abs(
+        (MAX_MOVEMENT_MULTIPLIER - creature.movementMultiplier) /
+          MOVEMENT_FACTOR
+      )
     );
     if (availMag < 1) return true;
 

--- a/static/index.html
+++ b/static/index.html
@@ -9,7 +9,7 @@
     <div id="gamediv-holder">
       <h1 class="title">Afterlight Caves</h1>
       <span id="version"
-        >Beta version 0.9.2 (<a
+        >Beta version 0.9.3 (<a
           href="https://github.com/bandaloo/afterlight-caves/releases"
           >changelog</a
         >)</span


### PR DESCRIPTION
-zoom editing drag was unnecessarily complicated and had worse handling.
- editing movement multiplier feels more natural.
- Hero no longer slides around.
- Easier and more understandable code-wise.